### PR TITLE
mmc1: fix duplicate function identifier

### DIFF
--- a/lib/mapper/mmc1.fab
+++ b/lib/mapper/mmc1.fab
@@ -91,7 +91,7 @@ asm fn mmc1_set_chr_1(U value)
         rts
 
 // Writes the CHR_1 register, the unsafe bank switch version:
-asm fn mmc1_set_chr_1(U value)
+asm fn mmc1_set_chr_1_unsafe(U value)
 : employs
 : +static
         lda &value


### PR DESCRIPTION
Building the `mmc1` example:

> nesfab ./mmc1/mmc1.cfg

results in the following build error:

> ```plain
> ../../../../../../../usr/share/nesfab/lib/mapper/mmc1.fab:94:8: error: Global identifier mmc1_set_chr_1 already in use.
>  94 | asm fn mmc1_set_chr_1(U value)
>              ^^^^^^^^^^^^^^
> ../../../../../../../usr/share/nesfab/lib/mapper/mmc1.fab:69:8: note: Previous definition here:
>  69 | asm fn mmc1_set_chr_1(U value)
>              ^^^^^^^^^^^^^^
> ```

Fix the duplicate definition by appending an `_unsafe` suffix, just like it was done with `mmc1_set_chr_0` vs. `mmc1_set_chr_0_unsafe`.
