### PR TITLE
`scanline_irq` example: use MMC3 to work around issue #21

### DIFF
--- a/examples/scanline_irq/scanline_irq.cfg
+++ b/examples/scanline_irq/scanline_irq.cfg
@@ -1,4 +1,4 @@
-mapper = 189
+mapper = mmc3
 output = scanline_irq.nes
 nesfab-dir = ../../
 input = lib/nes.fab


### PR DESCRIPTION
I suggest this as a quick ’n’ dirty workaround until mapper 189 can be fixed.

Closes #21.
