### PR TITLE
Docker build for cross-platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 !/lib/
 !/src/
 !/syntax_highlighting/
+!*[Dd]ocker*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:bookworm-slim
+
+WORKDIR /app
+
+COPY . /app
+
+RUN apt-get update && \
+  apt-get install -y \
+  gcc \
+  g++ \
+  make \
+  libboost-program-options-dev
+
+RUN make release

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  compiler:
+    image: local/nesfab:dev-intel #
+    platform: linux/amd64
+    command: ["./examples/build_all.sh"]
+    volumes: 
+      - ${PWD}/output:/app/output
+      - ${PWD}/examples:/app/examples


### PR DESCRIPTION
This branch adds a Dockerfile and example docker-compose config, intended for those on ARM based machines (ie Apple Silicon) can run nesfab without any changes to the underlying code or existing build scripts.

Development env:
- 2022 Macbook Pro M1 
- MacOS Ventura 13.6.4
- Docker Desktop 4.26.0
- Docker Engine 24.0.7
- Compose: 2.23.2

Compiling was tested against all of the projects in `/examples` with no errors. A random selection of the resulting ROMs were tested successfully in FCEUX, and a smaller set tested on a hardware NES-001 using an Everdrive N8 (not the Pro).

`Note:` the engine provided by Docker Desktop for MacOS is capable of compiling both ARM (linux/arm64) and Intel (linux/amd64) builds of `nesfab`, however the build time for linux/amd64 is an order of magnitude longer. Based on experience this is not unusual, especially when gcc is involved. I expect that it would be more performant on native Intel, however at this time I have no way to accurately verify (all my Intel machines are 2018 and older). Once the image was built, there was no noticeable impact to compile time for actual nesfab projects.

Any questions or feedback is always welcome.