### PR TITLE
Build on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ INCS:=-I$(SRCDIR)
 VERSION := "1.6"
 GIT_COMMIT := "$(shell git describe --all --abbrev=8 --dirty --always)"
 
-#override CXX:=clang++
+override CXX:=clang++
 
 override CXXFLAGS+= \
   -std=c++20 \

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ $(SRCDIR)/macro_lex_tables.hpp \
 $(SRCDIR)/macro_lex_tables.cpp
 
 lexer_gen: $(SRCDIR)/lexer_gen.cpp $(SRCDIR)/lex_op_name.inc
-	g++ -std=c++17 -O1 -o lexer_gen $<
+	$(CXX) -std=c++17 -O1 -o lexer_gen $<
 
 $(LEX_TABLES): lexer_gen $(SRCDIR)/lexer_gen.cpp $(SRCDIR)/lex_op_name.inc
 	./lexer_gen 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,16 @@ INCS:=-I$(SRCDIR)
 VERSION := "1.6"
 GIT_COMMIT := "$(shell git describe --all --abbrev=8 --dirty --always)"
 
-override CXX:=clang++
+ifneq ($(OS),Windows_NT)
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		override CLANG:=1
+	endif
+endif
+
+ifdef CLANG
+	override CXX:=clang++
+endif
 
 override CXXFLAGS+= \
   -std=c++20 \

--- a/src/array_pool.hpp
+++ b/src/array_pool.hpp
@@ -6,7 +6,7 @@
 #include <cassert>
 #include <memory>
 #include <vector>
-#include <deque>
+#include <boost/container/deque.hpp>
 #include <list>
 
 // A simple allocator that only supports allocation, not free.

--- a/src/decl.hpp
+++ b/src/decl.hpp
@@ -7,7 +7,7 @@
 #include <condition_variable>
 #include <functional>
 #include <mutex>
-#include <deque>
+#include <boost/container/deque.hpp>
 #include <type_traits>
 
 #include "flat/flat_map.hpp"
@@ -57,23 +57,23 @@ enum global_class_t : std::uint8_t
 #undef X
 };
 
-struct lt_ht : pool_handle_t<lt_ht, std::deque<lt_value_t>, PHASE_COMPILE> {};
+struct lt_ht : pool_handle_t<lt_ht, boost::container::deque<lt_value_t>, PHASE_COMPILE> {};
 
-struct global_ht : pool_handle_t<global_ht, std::deque<global_t>, PHASE_PARSE> {};
-struct fn_ht : pool_handle_t<fn_ht, std::deque<fn_t>, PHASE_PARSE> {};
-struct gvar_ht : pool_handle_t<gvar_ht, std::deque<gvar_t>, PHASE_PARSE> {};
-struct const_ht : pool_handle_t<const_ht, std::deque<const_t>, PHASE_PARSE> {};
-struct struct_ht : pool_handle_t<struct_ht, std::deque<struct_t>, PHASE_PARSE> {};
+struct global_ht : pool_handle_t<global_ht, boost::container::deque<global_t>, PHASE_PARSE> {};
+struct fn_ht : pool_handle_t<fn_ht, boost::container::deque<fn_t>, PHASE_PARSE> {};
+struct gvar_ht : pool_handle_t<gvar_ht, boost::container::deque<gvar_t>, PHASE_PARSE> {};
+struct const_ht : pool_handle_t<const_ht, boost::container::deque<const_t>, PHASE_PARSE> {};
+struct struct_ht : pool_handle_t<struct_ht, boost::container::deque<struct_t>, PHASE_PARSE> {};
 struct gmember_ht : pool_handle_t<gmember_ht, std::vector<gmember_t>, PHASE_COUNT_MEMBERS> {};
-struct charmap_ht : pool_handle_t<charmap_ht, std::deque<charmap_t>, PHASE_PARSE> {};
-struct fn_set_ht : pool_handle_t<fn_set_ht, std::deque<fn_set_t>, PHASE_PARSE> {};
+struct charmap_ht : pool_handle_t<charmap_ht, boost::container::deque<charmap_t>, PHASE_PARSE> {};
+struct fn_set_ht : pool_handle_t<fn_set_ht, boost::container::deque<fn_set_t>, PHASE_PARSE> {};
 
-struct group_ht : pool_handle_t<group_ht, std::deque<group_t>, PHASE_PARSE> 
+struct group_ht : pool_handle_t<group_ht, boost::container::deque<group_t>, PHASE_PARSE> 
 {
     group_data_t* data() const; // Defined in group.cpp
 };
-struct group_vars_ht : pool_handle_t<group_vars_ht, std::deque<group_t*>, PHASE_PARSE> {};
-struct group_data_ht : pool_handle_t<group_data_ht, std::deque<group_t*>, PHASE_PARSE_CLEANUP> {};
+struct group_vars_ht : pool_handle_t<group_vars_ht, boost::container::deque<group_t*>, PHASE_PARSE> {};
+struct group_data_ht : pool_handle_t<group_data_ht, boost::container::deque<group_t*>, PHASE_PARSE_CLEANUP> {};
 
 DEF_HANDLE_HASH(fn_ht);
 DEF_HANDLE_HASH(gvar_ht);

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -3,7 +3,7 @@
 #include <cassert>
 #include <cstdio>
 #include <stdexcept>
-#include <deque>
+#include <boost/container/deque.hpp>
 #include <mutex>
 
 #include "robin/set.hpp"
@@ -36,8 +36,8 @@ struct macro_result_t
 
 static std::mutex invoke_mutex;
 static rh::batman_set<macro_invocation_t> invoke_set;
-static std::deque<macro_result_t> macro_results;
-static std::deque<macro_result_t> new_macro_results;
+static boost::container::deque<macro_result_t> macro_results;
+static boost::container::deque<macro_result_t> new_macro_results;
 
 void invoke_macro(macro_invocation_t invoke)
 {

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -264,7 +264,7 @@ private:
 
     // Tracks chrroms: 
     inline static std::mutex chrrom_deque_mutex;
-    inline static std::deque<std::pair<global_t*, ast_node_t const*>> chrrom_deque;
+    inline static boost::container::deque<std::pair<global_t*, ast_node_t const*>> chrrom_deque;
 
     // These represent a queue of globals ready to be compiled.
     inline static std::condition_variable ready_cv;

--- a/src/lexer_gen.cpp
+++ b/src/lexer_gen.cpp
@@ -4,7 +4,7 @@
 #include <cassert>
 #include <cstdio>
 #include <cstdint>
-#include <deque>
+#include <boost/container/deque.hpp>
 #include <map>
 #include <memory>
 #include <numeric>
@@ -130,7 +130,7 @@ rptr maybe(rptr r)
     { return uor(clone(r), rptr(new regex_t{ EMPTY })); }
 
 nfa_t gen_nfa(regex_t const& regex, 
-              std::deque<nfa_node_t>& nodes, 
+              boost::container::deque<nfa_node_t>& nodes, 
               nfa_node_t* start = nullptr)
 {
     static unsigned prio = 0;
@@ -348,7 +348,7 @@ fc::vector_set<dfa_set_t> minimize_dfa(dfa_t& dfa)
     }
 }
 
-void print_nfa(nfa_t const& nfa, std::deque<nfa_node_t> const& nodes)
+void print_nfa(nfa_t const& nfa, boost::container::deque<nfa_node_t> const& nodes)
 {
     for(nfa_node_t const& n : nodes)
     {
@@ -624,7 +624,7 @@ rptr either_case_keyword(char const* a)
 
 int main()
 {
-    std::deque<nfa_node_t> nfa_nodes;
+    boost::container::deque<nfa_node_t> nfa_nodes;
     nfa_t nfa = gen_nfa(*uor(
         accept("eof", "file ending", eof()),
         accept("comment", "single-line comment", cat(word("//"), kleene(comchar()), uor(eof(), newline()))),
@@ -905,7 +905,7 @@ int main()
     dfa_t dfa = nfa_to_dfa(nfa);
     print_output(dfa, minimize_dfa(dfa), "lex", true);
 
-    std::deque<nfa_node_t> asm_nfa_nodes;
+    boost::container::deque<nfa_node_t> asm_nfa_nodes;
     nfa_t asm_nfa = gen_nfa(*
         uor(
 #define OP_NAME(name) either_case_keyword(#name),
@@ -918,7 +918,7 @@ int main()
     dfa_t asm_dfa = nfa_to_dfa(asm_nfa);
     print_output(asm_dfa, minimize_dfa(asm_dfa), "asm_lex", false);
 
-    std::deque<nfa_node_t> ext_nfa_nodes;
+    boost::container::deque<nfa_node_t> ext_nfa_nodes;
     nfa_t ext_nfa = gen_nfa(*uor(
         either_case_keyword("bin"),
         either_case_keyword("chr"),
@@ -932,7 +932,7 @@ int main()
     dfa_t ext_dfa = nfa_to_dfa(ext_nfa);
     print_output(ext_dfa, minimize_dfa(ext_dfa), "ext_lex", false);
 
-    std::deque<nfa_node_t> macro_nfa_nodes;
+    boost::container::deque<nfa_node_t> macro_nfa_nodes;
     nfa_t macro_nfa = gen_nfa(*uor(
         accept("eof", "file ending", eof()),
         keyword("backtick", "`"),

--- a/src/mapfab.cpp
+++ b/src/mapfab.cpp
@@ -76,7 +76,7 @@ struct mapfab_t
         unsigned h;
         std::vector<std::uint8_t> tiles;
         std::vector<std::uint8_t> tiles32;
-        std::vector<std::deque<std::string>> objects;
+        std::vector<boost::container::deque<std::string>> objects;
         std::vector<std::vector<std::int16_t>> objects_x;
         std::vector<std::vector<std::int16_t>> objects_y;
         std::vector<std::vector<std::string>> objects_name;
@@ -85,7 +85,7 @@ struct mapfab_t
     std::vector<chr_t> chrs;
     std::vector<palette_t> palettes;
     std::vector<mt_set_t> mt_sets;
-    fc::vector_map<std::string, std::deque<field_t>> ocs;
+    fc::vector_map<std::string, boost::container::deque<field_t>> ocs;
     std::vector<level_t> levels;
 
     void load_binary(std::uint8_t const* const begin, std::size_t size, fs::path mapfab_path);
@@ -240,7 +240,7 @@ void mapfab_t::load_binary(std::uint8_t const* const begin, std::size_t size, fs
         get8(); // R
         get8(); // G
         get8(); // B
-        std::deque<field_t> fields;
+        boost::container::deque<field_t> fields;
 
         unsigned const num_fields = get8();
         for(unsigned i = 0; i < num_fields; ++i)
@@ -415,7 +415,7 @@ void mapfab_t::load_json(std::uint8_t const* const begin, std::size_t size, fs::
         for(auto const& o : array)
         {
             std::string name = o.at("name").get<std::string>();
-            std::deque<field_t> fields;
+            boost::container::deque<field_t> fields;
 
             auto const& fs = o.at("fields").get<json::array_t>();
             for(auto const& f : fs)

--- a/src/o_loop.cpp
+++ b/src/o_loop.cpp
@@ -200,8 +200,8 @@ struct header_d
 };
 
 // iv = induction variable
-TLS std::deque<iv_t> ivs;
-TLS std::deque<mutual_iv_t> mutual_ivs;
+TLS boost::container::deque<iv_t> ivs;
+TLS boost::container::deque<mutual_iv_t> mutual_ivs;
 TLS std::vector<header_d> header_data_vec;
 
 template<typename Fn>

--- a/src/o_phi.cpp
+++ b/src/o_phi.cpp
@@ -1,6 +1,6 @@
 #include "o_phi.hpp"
 
-#include <deque>
+#include <boost/container/deque.hpp>
 
 #include <boost/container/small_vector.hpp>
 
@@ -113,7 +113,7 @@ private:
     void visit(ssa_ht phi_h);
 public:
     using scc_t = fc::small_set<ssa_ht, 2>;
-    std::deque<scc_t> sccs = {};
+    boost::container::deque<scc_t> sccs = {};
     std::size_t max_scc_size = 0;
     tarjan_t(ir_t& ir, unsigned subgraph_i,
              ssa_ht* phis, std::size_t phis_size);

--- a/src/object_pool.hpp
+++ b/src/object_pool.hpp
@@ -2,7 +2,7 @@
 #define OBJECT_POOL_HPP
 
 #include <memory>
-#include <deque>
+#include <boost/container/deque.hpp>
 #include <vector>
 
 // A basic memory pool that supports alloc and free.
@@ -17,7 +17,7 @@ public:
 
     using int_type = Int;
 private:
-    std::deque<T> storage;
+    boost::container::deque<T> storage;
     std::vector<T*> free_list;
 public:
     T& alloc() 

--- a/src/pass1.hpp
+++ b/src/pass1.hpp
@@ -63,8 +63,8 @@ private:
     fc::small_map<pstring_t, stmt_ht, 4, pstring_less_t> label_map;
     fc::small_multimap<pstring_t, stmt_ht, 4, pstring_less_t> unlinked_gotos;
 
-    std::deque<macro_todo_t> todo_macros;
-    std::deque<mapfab_todo_t> todo_mapfabs;
+    boost::container::deque<macro_todo_t> todo_macros;
+    boost::container::deque<mapfab_todo_t> todo_mapfabs;
 
     struct switch_info_t
     {

--- a/src/pbqp.hpp
+++ b/src/pbqp.hpp
@@ -13,7 +13,7 @@
 #include <array>
 #include <algorithm>
 #include <vector>
-#include <deque>
+#include <boost/container/deque.hpp>
 
 #include "assert.hpp"
 #include "debug_print.hpp"
@@ -106,7 +106,7 @@ private:
     bool optimal_reduction(pbqp_node_t& node);
     void heuristic_reduction(pbqp_node_t& node);
 
-    std::deque<pbqp_edge_t> edge_pool;
+    boost::container::deque<pbqp_edge_t> edge_pool;
     std::vector<pbqp_node_t*> bp_stack; // back propagation stack
     log_t* log;
 };

--- a/src/puf.cpp
+++ b/src/puf.cpp
@@ -1140,7 +1140,7 @@ void mem_wr(unsigned address, unsigned char data)
 const_ht convert_effect(lpstring_t at,
                         std::uint8_t const* const nsf_data, std::size_t nsf_size,
                         nsf_t const& nsf, unsigned song, unsigned mode,
-                        std::deque<nsf_track_t>& nsf_tracks,
+                        boost::container::deque<nsf_track_t>& nsf_tracks,
                         defined_group_data_t group_pair, bool omni)
 {
     unsigned const num_chan = puf_num_chan();
@@ -1358,7 +1358,7 @@ void convert_puf_sfx(char const* const txt_data, std::size_t txt_size,
 
     unsigned const num_chan = puf_num_chan();
 
-    std::deque<nsf_track_t> nsf_tracks;
+    boost::container::deque<nsf_track_t> nsf_tracks;
     nsf_track_t* active_track = nullptr;
 
     nsf_t nsf = {};

--- a/src/rom.hpp
+++ b/src/rom.hpp
@@ -193,9 +193,9 @@ rom_data_ht to_rom_data(asm_proc_t&& asm_proc, bool align, bool omni, romv_alloc
 // ROM alloc //
 ///////////////
 
-struct rom_static_ht : pool_handle_t<rom_static_ht, std::deque<rom_static_t>, PHASE_PREPARE_ALLOC_ROM> {};
-struct rom_many_ht : pool_handle_t<rom_many_ht, std::deque<rom_many_t>, PHASE_PREPARE_ALLOC_ROM> {};
-struct rom_once_ht : pool_handle_t<rom_once_ht, std::deque<rom_once_t>, PHASE_PREPARE_ALLOC_ROM> {};
+struct rom_static_ht : pool_handle_t<rom_static_ht, boost::container::deque<rom_static_t>, PHASE_PREPARE_ALLOC_ROM> {};
+struct rom_many_ht : pool_handle_t<rom_many_ht, boost::container::deque<rom_many_t>, PHASE_PREPARE_ALLOC_ROM> {};
+struct rom_once_ht : pool_handle_t<rom_once_ht, boost::container::deque<rom_once_t>, PHASE_PREPARE_ALLOC_ROM> {};
 
 DEF_HANDLE_HASH(rom_static_ht);
 DEF_HANDLE_HASH(rom_many_ht);

--- a/src/rom_decl.hpp
+++ b/src/rom_decl.hpp
@@ -3,7 +3,7 @@
 
 #include <cassert>
 #include <cstdint>
-#include <deque>
+#include <boost/container/deque.hpp>
 #include <functional>
 
 #include "handle.hpp"
@@ -23,8 +23,8 @@ struct rom_static_ht;
 struct rom_many_ht;
 struct rom_once_ht;
 
-struct rom_array_ht : public pool_handle_t<rom_array_ht, std::deque<rom_array_t>, PHASE_ROM_DUMMY> {};
-struct rom_proc_ht : public pool_handle_t<rom_proc_ht, std::deque<rom_proc_t>, PHASE_ROM_DUMMY> {};
+struct rom_array_ht : public pool_handle_t<rom_array_ht, boost::container::deque<rom_array_t>, PHASE_ROM_DUMMY> {};
+struct rom_proc_ht : public pool_handle_t<rom_proc_ht, boost::container::deque<rom_proc_t>, PHASE_ROM_DUMMY> {};
 
 class locator_t;
 

--- a/src/worklist.hpp
+++ b/src/worklist.hpp
@@ -1,7 +1,7 @@
 #ifndef WORKLIST_HPP
 #define WORKLIST_HPP
 
-#include <deque>
+#include <boost/container/deque.hpp>
 
 #include "flags.hpp"
 #include "ir_decl.hpp"
@@ -12,7 +12,7 @@ template<typename H>
 class worklist_t
 {
 public:
-    std::deque<H> container;
+    boost::container::deque<H> container;
 
     void push(H h)
     {


### PR DESCRIPTION
Since #14 was filed, some work has gone into making NESFab build on macOS. The missing piece is that the macOS system STL doesn't allow forward-declared data types in a deque. Fortunately, the Boost deque doesn't have that restriction and is a drop-in replacement.

This PR replaces STL deque with Boost's deque unconditionally. It also _conditionally_ uses Clang++ on macOS.